### PR TITLE
XandyBot v3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ This Discord bot does all the shenanigans Rene Alexander S. Castillo does in rea
 - Bot can give a random GIF from a specific Bocchi the Rock character of your choice.
 - Bot can now have a function to create a poll.
    - Polls should have at least two options. However, a poll author can have up to 10 options.
-   - Polls by default expire after 15 minutes. However, a poll author can set the poll duration by inputting the number of seconds the poll would expire in.
+   - Polls by default expire after 15 minutes. However, a poll author can set the poll duration by inputting the number of seconds or a parsable duration string. In the event you have inputted something invalid or a number/duration string that is less than 5 minutes, the poll would automatically expire after 5 minutes.
+      - The following strings could be parsed for the following units of time:
+         - days: "1d", "2 days", "3 day"
+         - hours: "1h", "2 hours", "3 hrs", "4hr", "5 hour"
+         - minutes: "1m", "2 min", "3 mins", "4 minutes", "5 minute"
+         - seconds: "1s", "2 secs", "3sec", "4 seconds", "5 second"
    - There is a button that can close the poll, which is visible to all users in the channel. However, only the poll author can really close the poll.
 
 ## Future Features

--- a/README.md
+++ b/README.md
@@ -12,7 +12,14 @@ This Discord bot does all the shenanigans Rene Alexander S. Castillo does in rea
 - Bot can give a random quote upon the request of a user by running `/clown`. This **should not** affect the scheduled sending of random quotes.
 - Bot can give a random image of the real Xander Castillo by running `/pogi`.
 - Bot can now give a notification if a streamer is currently live on Twitch (limited to only 4 streamers for now).
-- Bot can give a random GIF from a specific Bocchi the Rock character of your choice.
+- Bot can give a GIF from a specific Bocchi the Rock character of your choice **OR** choose a GIF from all the GIFs the bot has.
+   - User/s who invoke this command will have to respond to an ephemeral message sent by the bot where they would choose the GIF they want to send. They can opt to do the following options:
+      - Browse through the GIFs
+      - Choose shown GIF
+      - Cancel choosing a GIF
+   - There is no time limit really for choosing which GIF to send. However, there is a 10-second idle time that the bot waits for. What's consider idle are the following:
+      - Well, not doing anything after invoking the command for 10 seconds.
+      - Dismissing the ephemeral message - this is still within the 10-second idle time frame.
 - Bot can now have a function to create a poll.
    - Polls should have at least two options. However, a poll author can have up to 10 options.
    - Polls by default expire after 15 minutes. However, a poll author can set the poll duration by inputting the number of seconds or a parsable duration string. In the event you have inputted something invalid or a number/duration string that is less than 5 minutes, the poll would automatically expire after 5 minutes.

--- a/commands/bocchi.js
+++ b/commands/bocchi.js
@@ -1,16 +1,39 @@
 const { SlashCommandBuilder } = require("@discordjs/builders");
-const { getRandomBocchiGif } = require("../service/bocchiService");
+const {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  ComponentType,
+} = require("discord.js");
+const {
+  getAllBocchiGifs,
+  getBocchiGifsOfACharacter,
+} = require("../service/bocchiService");
+
+let currentUsers = [];
+
+const computeGifIndex = (customId, currentGifIndex, currentMaxIndex) => {
+  return customId === "previous"
+    ? currentGifIndex === 0
+      ? currentMaxIndex
+      : --currentGifIndex
+    : currentGifIndex === currentMaxIndex
+    ? 0
+    : ++currentGifIndex;
+};
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName("bocchi")
     .setDescription(
-      "I will give you a random GIF of a certain character from Bocchi the Rock."
+      "I will give you GIFs of characters from Bocchi the Rock. But you choose what to send!"
     )
     .addStringOption((option) =>
       option
         .setName("character")
-        .setDescription("The character you want a random GIF of")
+        .setDescription(
+          "The character you want to send a GIF of, but if not, you can check all first..."
+        )
         .setRequired(true)
         .addChoices(
           { name: "Bocchi (Hitori Gotoh)", value: "hitori-gotoh" },
@@ -20,7 +43,8 @@ module.exports = {
           { name: "Kikuri Hiroi", value: "kikuri-hiroi" },
           { name: "Seika Ijichi", value: "seika-ijichi" },
           { name: "Futari Gotoh", value: "futari-gotoh" },
-          { name: "Jimihen", value: "jimihen" }
+          { name: "Jimihen", value: "jimihen" },
+          { name: "All", value: "all" }
         )
     ),
   async execute(interaction) {
@@ -28,15 +52,137 @@ module.exports = {
 
     try {
       const character = interaction.options.getString("character");
-      const randomCharacterGIF = getRandomBocchiGif(character)["link"];
+      const userTag = interaction.member.user.tag;
 
-      console.info("Now sending random Bocchi GIF...");
+      const currentlyUsing = currentUsers.includes(userTag);
 
-      await interaction.reply({ content: randomCharacterGIF });
+      const slugBocchiAnimatedEmoji = "<a:slugbocchi:1094241815139454976>";
+
+      await interaction.reply({
+        content: currentlyUsing
+          ? "You are currently using the /bocchi command - either you are currently choosing a GIF or you have recently dismissed the message of choosing the GIF..."
+          : `${slugBocchiAnimatedEmoji}${slugBocchiAnimatedEmoji}${slugBocchiAnimatedEmoji}`,
+        ephemeral: currentlyUsing,
+      });
+
+      if (currentlyUsing) {
+        return;
+      }
+
+      currentUsers.push(userTag);
+
+      const listOfBocchiGifs =
+        character === "all"
+          ? getAllBocchiGifs()
+          : getBocchiGifsOfACharacter(character);
+
+      const characterName = character
+        .split("-")
+        .map((name) => name.charAt(0).toUpperCase() + name.substr(1))
+        .join(" ");
+
+      const pagedEmbeds = listOfBocchiGifs.map((gif) => {
+        return {
+          color: 0xcf37ca,
+          title:
+            characterName === "All"
+              ? "All GIFs of all characters!"
+              : `GIFs of ${characterName}`,
+          description: `**If you stay idle or dismiss this message within 10 seconds, then it's over! (timer resets if you click ◀️/▶️)**\n\nChoose the GIF you want to send by clicking ✅ or cancel choosing by clicking ❌`,
+          image: {
+            url: gif.link,
+          },
+          footer: {
+            text: "This bot is powered by Xander's money",
+          },
+        };
+      });
+
+      const row = new ActionRowBuilder().addComponents(
+        new ButtonBuilder()
+          .setCustomId("previous")
+          .setLabel("◀️")
+          .setStyle(ButtonStyle.Primary),
+        new ButtonBuilder()
+          .setCustomId("send")
+          .setLabel("✅")
+          .setStyle(ButtonStyle.Success),
+        new ButtonBuilder()
+          .setCustomId("cancel")
+          .setLabel("❌")
+          .setStyle(ButtonStyle.Danger),
+        new ButtonBuilder()
+          .setCustomId("next")
+          .setLabel("▶️")
+          .setStyle(ButtonStyle.Primary)
+      );
+
+      let gifIndex = 0;
+      const maxIndex = pagedEmbeds.length - 1;
+
+      const choosingGifMessage = await interaction.followUp({
+        embeds: [pagedEmbeds[gifIndex]],
+        components: [row],
+        ephemeral: true,
+        fetchReply: true,
+      });
+
+      const buttonCollector =
+        choosingGifMessage.createMessageComponentCollector({
+          componentType: ComponentType.Button,
+          idle: 10000,
+        });
+
+      let gifLink;
+
+      buttonCollector.on("collect", async (action) => {
+        await action.deferUpdate();
+
+        if (action.customId === "previous" || action.customId === "next") {
+          gifIndex = computeGifIndex(action.customId, gifIndex, maxIndex);
+
+          await action.editReply({
+            embeds: [pagedEmbeds[gifIndex]],
+            components: [row],
+          });
+        } else if (action.customId === "cancel") {
+          await buttonCollector.stop(
+            `${userTag} has opted to cancel choosing a Bocchi GIF!`
+          );
+        } else if (action.customId === "send") {
+          gifLink = listOfBocchiGifs[gifIndex].link;
+
+          await buttonCollector.stop(`${userTag} has chosen a Bocchi GIF!`);
+        }
+      });
+
+      buttonCollector.on("end", async (collected, reason) => {
+        currentUsers = currentUsers.filter(
+          (currentUserTag) => currentUserTag !== userTag
+        );
+
+        await interaction.deleteReply(choosingGifMessage);
+
+        if (reason.includes("cancel") || reason === "idle") {
+          setTimeout(async () => {
+            await interaction.deleteReply();
+          }, 100);
+        } else if (reason.includes("chosen")) {
+          setTimeout(async () => {
+            await interaction.editReply({
+              content: gifLink,
+            });
+
+            console.info("Now sending Bocchi GIF...");
+          }, 100);
+        }
+
+        console.debug(`Collected ${collected.size} button interactions!`);
+      });
     } catch (e) {
       console.error(`Error occurred when trying to do bocchi command: ${e}`);
     } finally {
-      console.debug("Bot has now released a Bocchi GIF...");
+      console.debug("Bot processing release of Bocchi GIF...");
     }
   },
 };

--- a/commands/help.js
+++ b/commands/help.js
@@ -95,7 +95,7 @@ module.exports = {
             case "bocchi":
               singleHelpEmbed = singleCommandEmbedBuilder(
                 "bocchi",
-                "I will give you a random GIF of a certain character from Bocchi the Rock.",
+                "I will give you GIFs of characters from Bocchi the Rock. But you choose what to send!",
                 '/bocchi <character>"'
               );
               break;

--- a/commands/help.js
+++ b/commands/help.js
@@ -102,7 +102,7 @@ module.exports = {
             case "poll":
               singleHelpEmbed = singleCommandEmbedBuilder(
                 "poll",
-                "Create a poll with up to 10 options! Polls expire after 15 minutes by default but you can set a time as long as it's at least 300 seconds.",
+                "Create a poll with up to 10 custom options! Polls expire after 15 minutes by default but you can set a time as long as it's at least 5 minutes.",
                 "/poll <question> <option-1> <option-2>"
               );
               break;

--- a/data/bocchi.json
+++ b/data/bocchi.json
@@ -1,6 +1,50 @@
 [
     {
+        "link": "https://media.tenor.com/JzdXdsl9TKsAAAAi/bocchi-rotate.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/-FrcCsUig4sAAAAC/spin-bocchi.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/aSaYnI7L9b0AAAAC/bocchi-the-rock-bocchi.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/TFyzEHB4RKAAAAAC/bocchi-the-rock.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/apAYwC8pEloAAAAd/bocchi-the-rock-anime.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/sUci_wuIivgAAAAC/bocchi-the-rock-gotou-hitori.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/Zs2uw1Zot_gAAAAC/bocchi-the-rock-gotou-hitori.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/nB9YSFNoDi8AAAAC/bocchi-the-rock-chainsaw-man.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/2GoQRjy7DVkAAAAC/bocchi-the-rock.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
         "link": "https://media.tenor.com/BntqMIZRFZ8AAAAC/bocchi-bocchi-the-rock.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/HlIF13WPxucAAAAC/bocchi-the-rock-anime.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/qkPV6_DL-NAAAAAC/bocchi-the-rock-bocchi.gif",
         "tags": "hitori-gotoh"
     },
     {
@@ -16,6 +60,10 @@
         "tags": "hitori-gotoh"
     },
     {
+        "link": "https://media.tenor.com/8WPW-T8L3nkAAAAC/bocchi-the-rock-bocchi.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
         "link": "https://media.tenor.com/KVFqRA1S1NoAAAAC/bocchi-the-rock-bocchi.gif",
         "tags": "hitori-gotoh"
     },
@@ -24,11 +72,55 @@
         "tags": "hitori-gotoh"
     },
     {
+        "link": "https://media.tenor.com/16LH1QP3r08AAAAC/bocchi-coffee-bocchi-the-rock.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/pnOD_aOtm_8AAAAd/bocchi-the-rock-hitori-gotoh.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/AOs4IHpAMEwAAAAC/anime-heart-pounding-bocchi-the-rock.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/TChjSFSGxUYAAAAC/hitori-gotou-gotou-hitori.gif",
+        "tags": "hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/USdY6pi_97gAAAAC/anime-bocchi.gif",
+        "tags": "hitori-gotoh,ikuyo-kita"
+    },
+    {
+        "link": "https://media.tenor.com/VbB6Y0m07C4AAAAC/bocchi-the-rock-ikuyo-kita.gif",
+        "tags": "ikuyo-kita,hitori-gotoh"
+    },
+    {
         "link": "https://media.tenor.com/iEJbN3O0yFkAAAAC/%E5%96%9C%E5%A4%9A%E9%83%81%E4%BB%A3-bocchi-the-rock.gif",
         "tags": "ikuyo-kita"
     },
     {
         "link": "https://media.tenor.com/_WvRwAlhge8AAAAC/bocchi-the-rock-kita-ikuyo.gif",
+        "tags": "ikuyo-kita"
+    },
+    {
+        "link": "https://media.tenor.com/5OHsT552MJIAAAAC/%E5%96%9C%E5%A4%9A%E9%83%81%E4%BB%A3-bocchi-the-rock.gif",
+        "tags": "ikuyo-kita"
+    },
+    {
+        "link": "https://media.tenor.com/xVuAYOsEP4wAAAAC/%E5%96%9C%E5%A4%9A%E9%83%81%E4%BB%A3-bocchi-the-rock.gif",
+        "tags": "ikuyo-kita"
+    },
+    {
+        "link": "https://media.tenor.com/aPcq8d1WewsAAAAC/bocchi-the-rock-kita-ikuyo.gif",
+        "tags": "ikuyo-kita"
+    },
+    {
+        "link": "https://media.tenor.com/p9uTQVQSAc4AAAAd/bocchitherock-bocchi.gif",
+        "tags": "ikuyo-kita"
+    },
+    {
+        "link": "https://media.tenor.com/tAyTQWwFDN0AAAAC/bocchi-the-rock-kita.gif",
         "tags": "ikuyo-kita"
     },
     {
@@ -42,6 +134,10 @@
     {
         "link": "https://media.tenor.com/KJ_he9DiCg0AAAAC/kita-ikuyo-bocchi-the-rock.gif",
         "tags": "ikuyo-kita"
+    },
+    {
+        "link": "https://media.tenor.com/a4Wrtj2iD68AAAAC/nijika-ijichi-kita-ikuyo.gif",
+        "tags": "ikuyo-kita,nijika-ijichi"
     },
     {
         "link": "https://media.tenor.com/wjzmCyKyXakAAAAC/nijika-ijichi-bocchi-the-rock.gif",
@@ -64,11 +160,35 @@
         "tags": "nijika-ijichi"
     },
     {
+        "link": "https://media.tenor.com/VcR9ipqZqboAAAAd/bozaro-bocchi-the-rock.gif",
+        "tags": "nijika-ijichi"
+    },
+    {
+        "link": "https://media.tenor.com/3QVCr249jagAAAAd/bozaro-bocchi-the-rock.gif",
+        "tags": "nijika-ijichi"
+    },
+    {
         "link": "https://media.tenor.com/WvoTD4uXIAwAAAAC/ryo-yamada-bocchi-the-rock.gif",
         "tags": "ryo-yamada"
     },
     {
+        "link": "https://media.tenor.com/cMkYc1Eqf1cAAAAC/bocchi-the-rock-bocchi.gif",
+        "tags": "ryo-yamada"
+    },
+    {
         "link": "https://media.tenor.com/XW8AKTDrh8oAAAAC/bocchi-the-rock-ryo.gif",
+        "tags": "ryo-yamada"
+    },
+    {
+        "link": "https://media.tenor.com/Bx3uEJf4Q2UAAAAC/ryou-yamada-ryo-yamada.gif",
+        "tags": "ryo-yamada"
+    },
+    {
+        "link": "https://media.tenor.com/iQ9Cd0LbN-4AAAAC/bocchi-the-rock-bocchi-the-rock-gif.gif",
+        "tags": "ryo-yamada,hitori-gotoh"
+    },
+    {
+        "link": "https://media.tenor.com/DfrupgNm5HsAAAAC/ryo-ryo-yamada.gif",
         "tags": "ryo-yamada"
     },
     {
@@ -81,6 +201,18 @@
     },
     {
         "link": "https://media.tenor.com/VwkgsgGnBjQAAAAC/ryou-ryo.gif",
+        "tags": "ryo-yamada"
+    },
+    {
+        "link": "https://media.tenor.com/C_L33cln6DMAAAAC/ryo-yamada-bocchi-the-rock.gif",
+        "tags": "ryo-yamada"
+    },
+    {
+        "link": "https://media.tenor.com/IpKKBfeBSqIAAAAC/distortion-vibing.gif",
+        "tags": "ryo-yamada"
+    },
+    {
+        "link": "https://media.tenor.com/kAGCvceHzE8AAAAC/bocchi-the-rock-ryo-yamada.gif",
         "tags": "ryo-yamada"
     },
     {
@@ -100,8 +232,20 @@
         "tags": "kikuri-hiroi"
     },
     {
+        "link": "https://media.tenor.com/0BITuYr2z0wAAAAd/kikuri-hiroi-bocchi.gif",
+        "tags": "kikuri-hiroi"
+    },
+    {
+        "link": "https://media.tenor.com/KovoKZY5ZFoAAAAC/kikuri-drunk.gif",
+        "tags": "kikuri-hiroi"
+    },
+    {
         "link": "https://media.tenor.com/shXbhKNq0VgAAAAC/hiroi-kikuri-bocchi-the-rock.gif",
         "tags": "kikuri-hiroi"
+    },
+    {
+        "link": "https://media.tenor.com/u342rrpGuiQAAAAd/nijika-ijichi-hiroi-kikuri.gif",
+        "tags": "kikuri-hiroi,nijika-ijichi"
     },
     {
         "link": "https://media.tenor.com/_qGN38gn41QAAAAC/bocchi-the-rock-bocchi.gif",
@@ -113,6 +257,10 @@
     },
     {
         "link": "https://media.tenor.com/ULhPW81FQAsAAAAC/bocchi-the-rock-gif-bocchi-the-rock.gif",
+        "tags": "seika-ijichi"
+    },
+    {
+        "link": "https://media.tenor.com/_y_NEEzQWewAAAAC/seika-ijichi-drinking.gif",
         "tags": "seika-ijichi"
     },
     {

--- a/deployCommands.js
+++ b/deployCommands.js
@@ -21,7 +21,7 @@ for (const file of commandFiles) {
   commands.push(command.data.toJSON());
 }
 
-const rest = new REST({ version: "9" }).setToken(token);
+const rest = new REST({ version: "10" }).setToken(token);
 
 (async () => {
   try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xandybot",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "XandyBot using Node.js",
   "main": "index.js",
   "scripts": {

--- a/service/bocchiService.js
+++ b/service/bocchiService.js
@@ -18,21 +18,12 @@ const getAllBocchiGifs = () => {
   return allBocchiGifs;
 };
 
-const getRandomBocchiGif = (character) => {
-  const allCharacterGifs = allBocchiGifs.filter((gif) =>
-    gif["tags"].includes(character)
-  );
-
-  const chosenCharacterGif =
-    allCharacterGifs[Math.floor(Math.random() * allCharacterGifs.length)];
-
-  console.info(`Found a random gif for ${character}...`);
-
-  return chosenCharacterGif;
+const getBocchiGifsOfACharacter = (character) => {
+  return allBocchiGifs.filter((gif) => gif["tags"].includes(character));
 };
 
 module.exports = {
   getAllBocchiGifsFromDatabase,
-  getRandomBocchiGif,
+  getBocchiGifsOfACharacter,
   getAllBocchiGifs,
 };


### PR DESCRIPTION
Updated the following commands:
- `/bocchi`
  - This is not entirely random anymore - upon invoking the command, the user can now choose what GIF to send depending on the character they choose, or can browse through all available GIFs. Also, they can opt to cancel choosing by pressing a button instead of dismissing the ephemeral message (API limitation - no way of handling dismissed ephemeral messages yet).
  - After idling for 10 seconds, the bot will automatically delete the messages that spawned from using the command. "Idling" here can mean not doing anything at all upon invoking the command, or dismissing the ephemeral message within 10 seconds.
  - Users cannot call the command again when the bot still waits for the user to choose a GIF or cancel choosing a GIF.
- `/poll`
  - The `close-in` optional input now accepts duration strings. It currently supports duration strings from days to seconds. (resolves #26)
  - In the event that the `close-in` input was given and the user gave a value (whether number or duration string) that is less than 300 seconds, the poll will then close after 300 seconds.